### PR TITLE
Add the ability to have a binary kafka key i.e have it be base64 encoded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = kastle
 PROJECT_DESCRIPTION = Apache Kafka REST Proxy
-PROJECT_VERSION = 1.2.1
+PROJECT_VERSION = 1.2.2
 
 # Whitespace to be used when creating files from templates.
 SP = 2


### PR DESCRIPTION
This is because we (CARP team) want to send avro encoded messages and the key is required to be binary.